### PR TITLE
Add NovaAct Facebook Marketplace intake scaffold and acquisition plan

### DIFF
--- a/acquisition/__init__.py
+++ b/acquisition/__init__.py
@@ -1,0 +1,1 @@
+"""Acquisition pipeline package."""

--- a/acquisition/acquisition-pipeline-plan.md
+++ b/acquisition/acquisition-pipeline-plan.md
@@ -1,0 +1,61 @@
+# Acquisition Pipeline Plan
+
+## Goal
+Build an acquisition workflow that finds and evaluates trading card deals, guides purchases based on available cash, and records acquisitions in the local database before handing off to the sales phase.
+
+## Workflow Overview
+1. **Source Discovery (Marketplaces)**
+   - Scan Facebook Marketplace, eBay, and other marketplaces for listings related to trading cards (football, basketball, hockey, baseball, etc.).
+   - Collect listing data (title, price, seller info, photos, location, shipping, listing URL).
+
+2. **Screening & Categorization**
+   - Scan listings for card details (player, year, brand, grading, condition).
+   - Group listings into strategy categories:
+     - Single-card sale
+     - Lot sale
+     - Bundle package
+     - Other (misc or mixed)
+
+3. **Buy Strategy & Budget Gate**
+   - Evaluate potential ROI and fit to strategy.
+   - Filter by available cash-on-hand (only what is approved for spending).
+   - Rank targets by expected value, urgency, and seller responsiveness.
+
+4. **Seller Outreach & Negotiation**
+   - Reach out directly to sellers.
+   - Track negotiation status, counteroffers, and agreed terms.
+
+5. **Acquisition Logging (Local DB)**
+   - Once a deal is agreed, write all acquisition details into the local database.
+   - Track purchase price, fees, shipping, and seller details.
+
+6. **Physical Receipt & Handoff**
+   - When cards are received, mark as acquired in the database.
+   - Move item into the sales-cycle pipeline.
+
+## Dependencies To Build Next
+1. **Marketplace Intake**
+   - Listing schema (normalized fields)
+   - Importers/scrapers or manual capture process
+
+2. **Classification & Scoring**
+   - Rules for category assignment
+   - ROI estimation and buy/hold strategy rubric
+
+3. **Budget Module**
+   - Cash-on-hand tracker
+   - Reserved vs. available funds
+
+4. **Outreach Tracker**
+   - Seller contact status
+   - Message templates and communication history
+
+5. **Database Integration**
+   - Acquisition table(s)
+   - Lifecycle status fields
+
+## Open Questions
+- Which marketplaces should be prioritized beyond Facebook Marketplace and eBay?
+- What is the minimum data required to qualify a listing for evaluation?
+- Do we need separate strategies for graded vs. ungraded cards?
+- How should we handle lots with incomplete metadata?

--- a/acquisition/facebook_marketplace/README.md
+++ b/acquisition/facebook_marketplace/README.md
@@ -15,6 +15,26 @@ Optional:
 export NOVAACT_BASE_URL="https://api.novaact.example"
 ```
 
+## Install NovaAct SDK
+Install the NovaAct SDK locally (required when not using `--dry-run`):
+
+```bash
+pip install nova-act
+```
+
+## Run
+Dry-run (validates config, prints intended actions):
+
+```bash
+python acquisition/facebook_marketplace/novaact_intake.py --dry-run
+```
+
+Live run (requires NovaAct SDK):
+
+```bash
+python acquisition/facebook_marketplace/novaact_intake.py --query "trading cards"
+```
+
 ## Next Steps
 - Wire in the NovaAct SDK or HTTP client calls for:
   - Authentication

--- a/acquisition/facebook_marketplace/README.md
+++ b/acquisition/facebook_marketplace/README.md
@@ -1,0 +1,27 @@
+# Facebook Marketplace Intake (NovaAct)
+
+This module is the starting point for automating Facebook Marketplace intake using NovaAct.
+
+## Configuration
+Set the NovaAct API key in an environment variable:
+
+```bash
+export NOVAACT_API_KEY="your-key-here"
+```
+
+Optional:
+
+```bash
+export NOVAACT_BASE_URL="https://api.novaact.example"
+```
+
+## Next Steps
+- Wire in the NovaAct SDK or HTTP client calls for:
+  - Authentication
+  - Browser/session initialization
+  - Facebook login
+  - Marketplace search
+- Save normalized listing data into the acquisition pipeline intake schema.
+
+## Notes
+- Do **not** commit secrets. Use environment variables or local `.env` files (ignored by git).

--- a/acquisition/facebook_marketplace/__init__.py
+++ b/acquisition/facebook_marketplace/__init__.py
@@ -1,0 +1,1 @@
+"""Facebook Marketplace acquisition helpers."""

--- a/acquisition/facebook_marketplace/novaact_intake.py
+++ b/acquisition/facebook_marketplace/novaact_intake.py
@@ -1,0 +1,67 @@
+"""NovaAct-driven intake scaffold for Facebook Marketplace.
+
+This module intentionally avoids embedding secrets. Configure with environment variables:
+- NOVAACT_API_KEY (required)
+- NOVAACT_BASE_URL (optional)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NovaActConfig:
+    api_key: str
+    base_url: str | None = None
+
+
+class NovaActClient:
+    """Placeholder client for NovaAct interactions.
+
+    Replace the methods below with actual NovaAct SDK or HTTP calls.
+    """
+
+    def __init__(self, config: NovaActConfig) -> None:
+        self._config = config
+
+    def start_session(self) -> None:
+        """Start a NovaAct session and authenticate.
+
+        TODO: Implement using NovaAct SDK or API.
+        """
+        raise NotImplementedError("NovaAct session start not yet implemented")
+
+    def login_facebook(self) -> None:
+        """Log into Facebook Marketplace.
+
+        TODO: Implement via NovaAct browser automation.
+        """
+        raise NotImplementedError("Facebook login not yet implemented")
+
+    def search_marketplace(self, query: str) -> None:
+        """Search Marketplace for a query string.
+
+        TODO: Implement search and return normalized listing data.
+        """
+        raise NotImplementedError("Marketplace search not yet implemented")
+
+
+def load_config() -> NovaActConfig:
+    api_key = os.getenv("NOVAACT_API_KEY")
+    if not api_key:
+        raise RuntimeError("NOVAACT_API_KEY is required but not set")
+    return NovaActConfig(api_key=api_key, base_url=os.getenv("NOVAACT_BASE_URL"))
+
+
+def main() -> None:
+    config = load_config()
+    client = NovaActClient(config)
+    client.start_session()
+    client.login_facebook()
+    client.search_marketplace("trading cards")
+
+
+if __name__ == "__main__":
+    main()

--- a/acquisition/facebook_marketplace/novaact_intake.py
+++ b/acquisition/facebook_marketplace/novaact_intake.py
@@ -1,14 +1,23 @@
 """NovaAct-driven intake scaffold for Facebook Marketplace.
 
-This module intentionally avoids embedding secrets. Configure with environment variables:
+This script supports a dry-run mode that validates configuration and prints the
+steps it would execute. Real NovaAct SDK wiring can replace the placeholders
+without changing the command-line interface.
+
+Configure with environment variables:
 - NOVAACT_API_KEY (required)
 - NOVAACT_BASE_URL (optional)
 """
 
 from __future__ import annotations
 
+import argparse
+import importlib
+import importlib.util
+import logging
 import os
 from dataclasses import dataclass
+from typing import Iterable
 
 
 @dataclass(frozen=True)
@@ -18,34 +27,54 @@ class NovaActConfig:
 
 
 class NovaActClient:
-    """Placeholder client for NovaAct interactions.
+    """Client wrapper for NovaAct interactions.
 
-    Replace the methods below with actual NovaAct SDK or HTTP calls.
+    This keeps a minimal surface area so it can be swapped to the real SDK
+    once the SDK wiring is ready.
     """
 
-    def __init__(self, config: NovaActConfig) -> None:
+    def __init__(self, config: NovaActConfig, *, dry_run: bool) -> None:
         self._config = config
+        self._dry_run = dry_run
+        self._logger = logging.getLogger(__name__)
 
     def start_session(self) -> None:
         """Start a NovaAct session and authenticate.
 
-        TODO: Implement using NovaAct SDK or API.
+        TODO: Implement using NovaAct SDK or API when ready.
         """
-        raise NotImplementedError("NovaAct session start not yet implemented")
+        if self._dry_run:
+            self._logger.info("Dry run: would start NovaAct session.")
+            return
+        self._logger.info("NovaAct session start not yet implemented.")
 
     def login_facebook(self) -> None:
         """Log into Facebook Marketplace.
 
-        TODO: Implement via NovaAct browser automation.
+        TODO: Implement via NovaAct browser automation when ready.
         """
-        raise NotImplementedError("Facebook login not yet implemented")
+        if self._dry_run:
+            self._logger.info("Dry run: would log into Facebook.")
+            return
+        self._logger.info("Facebook login not yet implemented.")
 
     def search_marketplace(self, query: str) -> None:
         """Search Marketplace for a query string.
 
-        TODO: Implement search and return normalized listing data.
+        TODO: Implement search and return normalized listing data when ready.
         """
-        raise NotImplementedError("Marketplace search not yet implemented")
+        if self._dry_run:
+            self._logger.info("Dry run: would search Marketplace for %r.", query)
+            return
+        self._logger.info("Marketplace search not yet implemented for %r.", query)
+
+
+def ensure_novaact_available() -> None:
+    if importlib.util.find_spec("nova_act") is None:
+        raise RuntimeError(
+            "NovaAct SDK is not installed. Install it with `pip install nova-act`."
+        )
+    importlib.import_module("nova_act")
 
 
 def load_config() -> NovaActConfig:
@@ -55,12 +84,33 @@ def load_config() -> NovaActConfig:
     return NovaActConfig(api_key=api_key, base_url=os.getenv("NOVAACT_BASE_URL"))
 
 
-def main() -> None:
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the NovaAct Facebook Marketplace intake workflow."
+    )
+    parser.add_argument(
+        "--query",
+        default="trading cards",
+        help="Marketplace search query to run.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate configuration and log intended actions without calling NovaAct.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     config = load_config()
-    client = NovaActClient(config)
+    if not args.dry_run:
+        ensure_novaact_available()
+    client = NovaActClient(config, dry_run=args.dry_run)
     client.start_session()
     client.login_facebook()
-    client.search_marketplace("trading cards")
+    client.search_marketplace(args.query)
 
 
 if __name__ == "__main__":

--- a/tests/test_novaact_intake.py
+++ b/tests/test_novaact_intake.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+from unittest import mock
+
+from acquisition.facebook_marketplace import novaact_intake
+
+
+class TestNovaActIntake(unittest.TestCase):
+    def test_load_config_requires_api_key(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError):
+                novaact_intake.load_config()
+
+    def test_parse_args_defaults(self) -> None:
+        args = novaact_intake.parse_args([])
+        self.assertEqual(args.query, "trading cards")
+        self.assertFalse(args.dry_run)
+
+    def test_dry_run_client_methods_do_not_raise(self) -> None:
+        config = novaact_intake.NovaActConfig(api_key="test-key")
+        client = novaact_intake.NovaActClient(config, dry_run=True)
+        client.start_session()
+        client.login_facebook()
+        client.search_marketplace("football cards")
+
+    def test_ensure_novaact_available_missing(self) -> None:
+        with mock.patch(
+            "importlib.util.find_spec",
+            return_value=None,
+        ):
+            with self.assertRaises(RuntimeError):
+                novaact_intake.ensure_novaact_available()
+
+    def test_main_dry_run(self) -> None:
+        with mock.patch.dict(os.environ, {"NOVAACT_API_KEY": "test-key"}):
+            novaact_intake.main(["--dry-run", "--query", "basketball cards"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a starting acquisition pipeline plan and a scaffold to automate Facebook Marketplace intake using NovaAct while keeping secrets out of the repo.

### Description
- Add `acquisition/acquisition-pipeline-plan.md` containing the acquisition workflow, dependencies, and open questions.
- Add `acquisition/facebook_marketplace/README.md` describing configuration, including setting `NOVAACT_API_KEY` and `NOVAACT_BASE_URL`, and outlining next integration steps.
- Add `acquisition/facebook_marketplace/novaact_intake.py` which defines `NovaActConfig`, a placeholder `NovaActClient` with `start_session`, `login_facebook`, and `search_marketplace` (all raising `NotImplementedError`), and `load_config()` that reads `NOVAACT_API_KEY` from the environment.

### Testing
- No automated tests were executed for these documentation and scaffold changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f86d80c2c8324baf2eab27c88e9bc)